### PR TITLE
Typing/mypy improvements

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,2 +1,10 @@
 [mypy]
+
+[mypy-boto3.*]
+ignore_missing_imports = True
+
+[mypy-moto.*]
+ignore_missing_imports = True
+
+[mypy-setuptools.*]
 ignore_missing_imports = True

--- a/fastapi_events/py.typed
+++ b/fastapi_events/py.typed
@@ -1,0 +1,1 @@
+# marker file for PEP 561

--- a/fastapi_events/registry/base.py
+++ b/fastapi_events/registry/base.py
@@ -1,14 +1,15 @@
 import logging
 from abc import ABCMeta
 from collections import UserDict
+from typing import Optional, Type
 
 logger = logging.getLogger(__name__)
 
+BaseModel: Optional[Type] = None
 try:
     from pydantic import BaseModel
 except ImportError:
     logger.warning("Pydantic is required to use schema registry")
-    BaseModel = None
 
 
 class BaseEventPayloadSchemaRegistry(UserDict, metaclass=ABCMeta):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 minversion = 6.2
 
+addopts = --mypy
 python_files = test_*.py
 asyncio_mode=auto
 env =

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/melvinkcx/fastapi-events",
     packages=setuptools.find_packages(exclude=["tests.*"]),
+    package_data={"fastapi_events": ["py.typed"]},
     classifiers={
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
@@ -51,6 +52,8 @@ setuptools.setup(
             "pytest-asyncio>=0.18.3",
             "pytest-env>=0.6.2",
             "pytest-mock>=3.6.1",
+            "mypy>=0.971",
+            "pytest-mypy>=0.9.1",
             "moto[sqs]==2.2",
             "flake8>=3.9.2",
             "pydantic>=1.5.0"

--- a/tests/handlers/test_local_handler.py
+++ b/tests/handlers/test_local_handler.py
@@ -21,7 +21,7 @@ def setup_test() -> Callable:
 
         @app.route("/events")
         async def root(request: Request) -> JSONResponse:
-            dispatch(event_name=request.query_params.get("event"))
+            dispatch(event_name=request.query_params["event"])
             return JSONResponse([])
 
         return app, handler


### PR DESCRIPTION
I have made some typing/mypy improvements:

1. fixed two mypy failures
2. explicitly defined the dependencies which are not compatible with mypy
3. added _mypy_ and _pytest-mypy_ to the test dependencies so that _pytest_ can run the checks automatically
4. added _py.typed_ stub file to flag upstream code that _fastapi-events_ is PEP 561 compliant

Cheers!
Kyle