### PR TITLE
fixed a bug with custom middleware_id

### DIFF
--- a/fastapi_events/middleware.py
+++ b/fastapi_events/middleware.py
@@ -23,9 +23,10 @@ class EventHandlerASGIMiddleware:
 
     def __del__(self):
         """
-        Removing handlers after middleware is necessary as `self._id` is generated with the built-in `id()`
+        Removing handlers after middleware is necessary when `self._id` == `id(self)`
         """
-        self.deregister_handlers()
+        if self._id == id(self):
+            self.deregister_handlers()
 
     def register_handlers(self, handlers: Iterable[BaseEventHandler]) -> None:
         handler_store[self._id] = handlers


### PR DESCRIPTION
The call to `deregister_handlers()` from `__del__` is only needed when `self._id == id(self)`.

Once I integrated this into a larger app with more middleware, the handlers started getting garbage collected and the entire events system grinded to a halt.

Cheers!
Kyle