### PR TITLE
remove Starlette as an install dependency

### DIFF
--- a/fastapi_events/handlers/aws.py
+++ b/fastapi_events/handlers/aws.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from typing import Callable, Iterable
+from typing import Callable, Iterable, Optional
 
 import boto3
 
@@ -28,8 +28,8 @@ class SQSForwardHandler(BaseEventHandler):
         self,
         queue_url: str,
         region_name: str,
-        serializer: Callable[[Event], str] = None,
-        id_generator: Callable[[Event], str] = None,
+        serializer: Optional[Callable[[Event], str]] = None,
+        id_generator: Optional[Callable[[Event], str]] = None,
         max_batch_size: int = 10,  # AWS supports up to 10 messages at once
         **boto_client_kwargs
     ):

--- a/fastapi_events/handlers/gcp.py
+++ b/fastapi_events/handlers/gcp.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Callable, Dict, Iterable
+from typing import Any, Callable, Dict, Iterable, Optional
 
 from google.cloud import pubsub_v1
 
@@ -18,8 +18,8 @@ class GoogleCloudSimplePubSubHandler(BaseEventHandler):
         project_id: str,
         topic_id: str,
         max_batch_size: int = 1000,  # GCP Pubsub's maximum supported batch size
-        batch_settings_kwargs: Dict[str, Any] = None,
-        serializer: Callable[[Event], str] = None,
+        batch_settings_kwargs: Optional[Dict[str, Any]] = None,
+        serializer: Optional[Callable[[Event], str]] = None,
     ) -> None:
         """Google cloud simple PubSub handler. Publishes events to a single topic."""
 

--- a/fastapi_events/middleware.py
+++ b/fastapi_events/middleware.py
@@ -59,7 +59,7 @@ class EventHandlerASGIMiddleware:
             middleware_identifier.reset(token_middleware_id)
 
     @contextlib.contextmanager
-    def res_req_cycle_ctx(self):
+    def res_req_cycle_ctx(self) -> Iterator[None]:
         token_is_res_req_cycle: Token = in_req_res_cycle.set(True)
 
         try:

--- a/fastapi_events/middleware.py
+++ b/fastapi_events/middleware.py
@@ -5,12 +5,10 @@ from collections import deque
 from contextvars import Token
 from typing import Deque, Iterable, Iterator, Optional
 
-from starlette.types import ASGIApp, Receive, Scope, Send
-
 from fastapi_events import (event_store, handler_store, in_req_res_cycle,
                             middleware_identifier)
 from fastapi_events.handlers.base import BaseEventHandler
-from fastapi_events.typing import Event
+from fastapi_events.typing import ASGIApp, Event, Receive, Scope, Send
 
 logger = logging.getLogger(__name__)
 

--- a/fastapi_events/otel/trace/__init__.py
+++ b/fastapi_events/otel/trace/__init__.py
@@ -1,11 +1,11 @@
 from fastapi_events.otel import HAS_OTEL_INSTALLED
 
 if HAS_OTEL_INSTALLED:
-    from opentelemetry import trace  # type: ignore
+    from opentelemetry import trace
 
     get_tracer = trace.get_tracer
 
 else:
     from fastapi_events.otel.trace import dummy
 
-    get_tracer = dummy.Tracer()
+    get_tracer = dummy.Tracer()  # type: ignore[assignment]

--- a/fastapi_events/typing.py
+++ b/fastapi_events/typing.py
@@ -1,4 +1,9 @@
 from enum import Enum
-from typing import Any, Tuple, Union
+from typing import Any, Awaitable, Callable, MutableMapping, Tuple, Union
 
 Event = Tuple[Union[str, Enum], Any]
+Scope = MutableMapping[str, Any]
+Message = MutableMapping[str, Any]
+Receive = Callable[[], Awaitable[Message]]
+Send = Callable[[Message], Awaitable[None]]
+ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setuptools.setup(
     },
     python_requires=">=3.7",
     keywords=["starlette", "fastapi", "pydantic"],
-    install_requires=["starlette"],
     extras_require={
         "test": [
             "requests",
@@ -60,7 +59,9 @@ setuptools.setup(
             "pydantic>=1.5.0",
             "google-cloud-pubsub>=2.13.6",
             "opentelemetry-sdk>=1.12.0",
-            "opentelemetry-test-utils>=0.33b0"
+            "opentelemetry-test-utils>=0.33b0",
+            "starlette>=0.21.0",
+            "httpx>=0.23.0",
         ],
         "aws": ["boto3>=1.14"],
         "google": ["google-cloud-pubsub>=2.13.6"],

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -81,8 +81,8 @@ async def test_payload_validation_with_pydantic_in_req_res_cycle(
 
     @payload_schema.register(event_name=UserEvents.SIGNED_UP)
     class _SignUpEventSchema(pydantic.BaseModel):
-        user_id: uuid.UUID
-        created_at: datetime
+        user_id: uuid.UUID  # type: ignore[annotation-unchecked]
+        created_at: datetime  # type: ignore[annotation-unchecked]
 
     dispatch_fn = functools.partial(dispatch,
                                     event_name=UserEvents.SIGNED_UP,


### PR DESCRIPTION
I have been using `fastapi-events` with [Starlite](https://starlite-api.github.io/starlite/), and it works great since `fastapi-events` is pure ASGI middleware.

For a while, `Starlite` was using a number of components from `Starlette` but it now has no dependency on `Starlette`. `fastapi-events`'s only non-testing dependency on `Starlette` is some ASGI typing imports. This PR creates those types locally in typing.py and moves `Starlette` to the test dependencies. This will keep `Starlette` from being installed when used with non `Starlette`/`FastAPI` frameworks.

I may even cook up a Documentation PR with an example of how to use it with `Starlite`.

Thanks!
Kyle