### PR TITLE
FastAPI Dependency Support For Local Handler

### DIFF
--- a/fastapi_events/handlers/local.py
+++ b/fastapi_events/handlers/local.py
@@ -2,10 +2,153 @@ import asyncio
 import fnmatch
 import functools
 import inspect
+import sys
+from typing import Any, Callable, Dict, ForwardRef, List, Optional, Tuple, cast
+
+# TODO Try to completely eliminate the need of using dependent libs
+from fastapi import params  # FIXME
+from pydantic.error_wrappers import ErrorWrapper
 
 from fastapi_events.handlers.base import BaseEventHandler
 from fastapi_events.otel.utils import create_span_for_handle_fn
 from fastapi_events.typing import Event
+
+
+def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
+    """
+    Adopted from pydantic source code
+    """
+    if sys.version_info < (3, 9):
+        return type_._evaluate(globalns, localns)
+    else:
+        # Even though it is the right signature for python 3.9, mypy complains with
+        # `error: Too many arguments for "_evaluate" of "ForwardRef"` hence the cast...
+        return cast(Any, type_)._evaluate(globalns, localns, set())
+
+
+def get_typed_annotation(
+    annotation: Any,
+    globalns: Dict[str, Any]
+) -> Any:
+    """
+    Adopted from fastapi source code
+    """
+    if isinstance(annotation, str):
+        annotation = ForwardRef(annotation)
+        annotation = evaluate_forwardref(annotation, globalns, globalns)
+    return annotation
+
+
+def get_typed_signature(
+    call: Callable[..., Any]
+) -> inspect.Signature:
+    """
+    Adopted from fastapi source code
+    """
+    signature = inspect.signature(call)
+    globalns = getattr(call, "__globals__", {})
+    typed_params = [
+        inspect.Parameter(
+            name=param.name,
+            kind=param.kind,
+            default=param.default,
+            annotation=get_typed_annotation(param.annotation, globalns),
+        )
+        for param in signature.parameters.values()
+    ]
+    typed_signature = inspect.Signature(typed_params)
+    return typed_signature
+
+
+class Dependant:
+    def __init__(
+        self,
+        call: Callable[..., Any],
+        name: str,
+        dependencies: Optional[List["Dependant"]] = None,
+    ):
+        self.call = call
+        self.name = name
+        self.dependencies = dependencies or []
+
+
+def get_param_sub_dependant(
+    *,
+    param: inspect.Parameter,
+    name: str,
+) -> Dependant:
+    depends: params.Depends = param.default
+    if depends.dependency:
+        dependency = depends.dependency
+    else:
+        dependency = param.annotation
+
+    return get_dependant(
+        name=name,
+        call=dependency,
+    )
+
+
+def get_dependant(
+    *,
+    call: Callable[..., Any],
+    name: str = None,
+) -> Dependant:
+    handler_signature = get_typed_signature(call)
+    signature_params = handler_signature.parameters
+
+    dependant = Dependant(
+        call=call,
+        name=name,
+    )
+
+    for param_name, param in signature_params.items():
+        if isinstance(param.default, params.Depends):  # FIXME create a Protocol for params.Depends?
+            sub_dependant = get_param_sub_dependant(
+                param=param,
+                name=param_name,
+            )
+            dependant.dependencies.append(sub_dependant)
+            continue
+
+    return dependant
+
+
+async def solve_dependencies(
+    *,
+    event: Event,
+    dependant: Dependant,
+) -> Tuple[
+    Dict[str, Any],
+    List[ErrorWrapper]
+]:
+    values: Dict[str, Any] = {}
+    errors: List[ErrorWrapper] = []
+
+    for sub_dependant in dependant.dependencies:
+        use_sub_dependant = sub_dependant
+        call = sub_dependant.call
+
+        sub_values, sub_errors = await solve_dependencies(
+            event=event,
+            dependant=use_sub_dependant,
+        )
+        if sub_errors:
+            errors.extend(sub_errors)
+            continue
+
+        # TODO support dependencies with `yield`
+
+        elif asyncio.iscoroutinefunction(call):
+            solved = await call(**sub_values)
+        else:
+            loop = asyncio.get_event_loop()
+            solved = await loop.run_in_executor(None, functools.partial(call, event, **sub_values))
+
+        if sub_dependant.name is not None:
+            values[sub_dependant.name] = solved
+
+    return values, errors
 
 
 class LocalHandler(BaseEventHandler):
@@ -31,8 +174,12 @@ class LocalHandler(BaseEventHandler):
             payload=payload,
         ):
             for handler in self._get_handlers_for_event(event_name=event_name):
+                # #41 resolve dependencies
+                dependant = get_dependant(call=handler)
+                values, errors = await solve_dependencies(event=event, dependant=dependant)
+
                 if inspect.iscoroutinefunction(handler):
-                    await handler(event)
+                    await handler(event, **values)
                 else:
                     # Making sure sync function will never block the event loop
                     loop = asyncio.get_event_loop()

--- a/fastapi_events/handlers/local.py
+++ b/fastapi_events/handlers/local.py
@@ -64,7 +64,7 @@ class Dependant:
     def __init__(
         self,
         call: Callable[..., Any],
-        name: str,
+        name: Optional[str],
         dependencies: Optional[List["Dependant"]] = None,
     ):
         self.call = call
@@ -92,7 +92,7 @@ def get_param_sub_dependant(
 def get_dependant(
     *,
     call: Callable[..., Any],
-    name: str = None,
+    name: Optional[str] = None,
 ) -> Dependant:
     handler_signature = get_typed_signature(call)
     signature_params = handler_signature.parameters

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setuptools.setup(
             "starlette>=0.21.0",
             "starlite>=1.38.0",
             "httpx>=0.23.0",
+            "fastapi>=0.92.0",  # FIXME
         ],
         "aws": ["boto3>=1.14"],
         "google": ["google-cloud-pubsub>=2.13.6"],


### PR DESCRIPTION
First version:
- Sub-dependencies are supported
- Dependency cache is not supported
- Dependency override is not supported
- Generator dependencies with `yield` are not supported yet

Closes #41 