### PR TITLE
refactor: remove error return from solve_dependencies

### DIFF
--- a/fastapi_events/handlers/local.py
+++ b/fastapi_events/handlers/local.py
@@ -3,7 +3,7 @@ import fnmatch
 import functools
 import inspect
 import sys
-from typing import Any, Callable, Dict, ForwardRef, List, Optional, Tuple, cast
+from typing import Any, Callable, Dict, ForwardRef, List, Optional, cast
 
 # TODO Try to completely eliminate the need of using dependent libs
 from fastapi import params  # FIXME

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setuptools.setup(
             "moto[sqs]==2.2",
             "flake8>=3.9.2",
             "isort>=5.10.1",
-            "pydantic>=1.5.0",
+            "pydantic>=1.5.0,<2.0.0",
             "google-cloud-pubsub>=2.13.6",
             "opentelemetry-sdk>=1.12.0",
             "opentelemetry-test-utils>=0.33b0",


### PR DESCRIPTION
As reported on issue #45, with the new pydantic version "ErrorWrapper" is not supported.  
I have noticed that the return value error on "solve_dependencies" is not used, so I removed it.