### PR TITLE
Support dispatching Pydantic model; Support implicit event name

### DIFF
--- a/fastapi_events/__init__.py
+++ b/fastapi_events/__init__.py
@@ -9,7 +9,7 @@ __version__ = "0.9.1"
 # handlers keeps track of all handlers registered via EventHandlerASGIMiddleware
 handler_store: Dict[int, Iterable[BaseEventHandler]] = defaultdict(list)
 
-# event_store keeps track of all events dispatched the request-response cycle
+# event_store keeps track of all events dispatched in a request-response cycle
 event_store: ContextVar = ContextVar("fastapi_event_store")
 
 # in_req_res_cycle is set to allow dispatch() to work in event handlers

--- a/fastapi_events/dispatcher.py
+++ b/fastapi_events/dispatcher.py
@@ -88,9 +88,6 @@ def _set_middleware_identifier(middleware_id: int) -> Iterator[None]:
         middleware_identifier.reset(token_middleware_id)
 
 
-# FIXME maybe I can use @functools.singledispatch here?
-# no, singledispatch fn must be called with at least 1 positional argument
-
 def dispatch(
     event_name_or_model: Union[str, Enum, Any] = None,
     payload: Optional[Any] = None,
@@ -134,7 +131,7 @@ def dispatch(
             # Handle dispatch of pydantic Model
             if isinstance(event_name_or_model, pydantic.BaseModel):
                 if not event_name:
-                    event_name = getattr(event_name_or_model, "__event_name__")
+                    event_name = getattr(event_name_or_model, "__event_name__", None)
 
                 if not event_name:
                     raise MissingEventNameDuringDispatch

--- a/fastapi_events/dispatcher.py
+++ b/fastapi_events/dispatcher.py
@@ -88,6 +88,7 @@ def _set_middleware_identifier(middleware_id: int) -> Iterator[None]:
         middleware_identifier.reset(token_middleware_id)
 
 
+# skipcq: PY-R1000
 def dispatch(
     event_name_or_model: Union[str, Enum, Any] = None,
     payload: Optional[Any] = None,

--- a/fastapi_events/dispatcher.py
+++ b/fastapi_events/dispatcher.py
@@ -92,7 +92,6 @@ def _set_middleware_identifier(middleware_id: int) -> Iterator[None]:
 # no, singledispatch fn must be called with at least 1 positional argument
 
 def dispatch(
-    # FIXME Can be either event_name or Pydantic model (support positional arg)
     event_name_or_model: Union[str, Enum, Any] = None,
     payload: Optional[Any] = None,
     event_name: Union[str, Enum] = None,  # this will be prioritized

--- a/fastapi_events/dispatcher.py
+++ b/fastapi_events/dispatcher.py
@@ -148,7 +148,6 @@ def _validate_payload(
     return payload
 
 
-# skipcq: PY-R1000
 def dispatch(
     event_name_or_model: Union[EventName, Any] = None,
     payload: Optional[Any] = None,

--- a/fastapi_events/errors.py
+++ b/fastapi_events/errors.py
@@ -4,3 +4,12 @@ class FastapiEventError(BaseException):
 
 class ConfigurationError(FastapiEventError):
     pass
+
+
+class MissingEventNameDuringRegistration(FastapiEventError):
+    def __init__(self):
+        super().__init__(
+            "Event name cannot be determined during schema registration. "
+            "Please ensure '__event_name__' is defined in your payload schema "
+            "or 'event_name' is provided to @payload_schema.register() as a kwarg."
+        )

--- a/fastapi_events/errors.py
+++ b/fastapi_events/errors.py
@@ -6,10 +6,31 @@ class ConfigurationError(FastapiEventError):
     pass
 
 
-class MissingEventNameDuringRegistration(FastapiEventError):
+class MissingEventNameError(FastapiEventError):
+    pass
+
+
+class MissingEventNameDuringRegistration(MissingEventNameError):
     def __init__(self):
         super().__init__(
             "Event name cannot be determined during schema registration. "
             "Please ensure '__event_name__' is defined in your payload schema "
             "or 'event_name' is provided to @payload_schema.register() as a kwarg."
+        )
+
+
+class MissingEventNameDuringDispatch(MissingEventNameError):
+    def __init__(self):
+        super().__init__(
+            "Event name cannot be determined during dispatch. "
+            "Please ensure 'event_name' is provided to dispatch() as an argument "
+            "or '__event_name__' is defined in your payload schema."
+        )
+
+
+class MultiplePayloadsDetectedDuringDispatch(FastapiEventError, ValueError):
+    def __init__(self):
+        super().__init__(
+            "Multiple payloads detected during dispatch. "
+            "Please ensure you're not providing both dict and pydantic.Model at the same time."
         )

--- a/fastapi_events/registry/base.py
+++ b/fastapi_events/registry/base.py
@@ -3,6 +3,8 @@ from abc import ABCMeta
 from collections import UserDict
 from typing import Optional, Type
 
+from fastapi_events.errors import MissingEventNameDuringRegistration
+
 logger = logging.getLogger(__name__)
 
 BaseModel: Optional[Type] = None
@@ -19,17 +21,31 @@ class BaseEventPayloadSchemaRegistry(UserDict, metaclass=ABCMeta):
     """
 
     def register(self, _schema=None, event_name=None):
-        if not event_name:
-            raise ValueError("'event_name' must be provided when registering a schema")
+        def _derive_event_name(_schema):
+            """
+            this modifies `event_name` in the scope
+            """
+            nonlocal event_name
+
+            if not event_name:
+                event_name = getattr(_schema, "__event_name__", None)
+
+            if not event_name:
+                raise MissingEventNameDuringRegistration
 
         def _wrap(schema):
             if BaseModel and not issubclass(schema, BaseModel):
                 raise AssertionError("'schema' must be a subclass of Pydantic BaseModel")
 
+            _derive_event_name(_schema=schema)
             self.data[event_name] = schema
+
             return schema
 
         if _schema is None:
             return _wrap
+
+        _derive_event_name(_schema=_schema)
+        self.data[event_name] = _schema
 
         return _schema

--- a/fastapi_events/typing.py
+++ b/fastapi_events/typing.py
@@ -1,7 +1,10 @@
 from enum import Enum
 from typing import Any, Awaitable, Callable, MutableMapping, Tuple, Union
 
-Event = Tuple[Union[str, Enum], Any]
+EventName = Union[str, Enum]
+Event = Tuple[EventName, Any]
+PydanticModel = Any  # FIXME
+Payload = Union[dict, PydanticModel]
 Scope = MutableMapping[str, Any]
 Message = MutableMapping[str, Any]
 Receive = Callable[[], Awaitable[Message]]

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -13,7 +13,7 @@ import fastapi_events.dispatcher as dispatcher_module
 from fastapi_events import BaseEventHandler, handler_store
 from fastapi_events.constants import FASTAPI_EVENTS_DISABLE_DISPATCH_ENV_VAR
 from fastapi_events.dispatcher import dispatch
-from fastapi_events.errors import FastapiEventError, MultiplePayloadsDetectedDuringDispatch
+from fastapi_events.errors import MultiplePayloadsDetectedDuringDispatch
 from fastapi_events.registry.payload_schema import EventPayloadSchemaRegistry
 from fastapi_events.typing import Event
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -13,6 +13,7 @@ import fastapi_events.dispatcher as dispatcher_module
 from fastapi_events import BaseEventHandler, handler_store
 from fastapi_events.constants import FASTAPI_EVENTS_DISABLE_DISPATCH_ENV_VAR
 from fastapi_events.dispatcher import dispatch
+from fastapi_events.errors import FastapiEventError, MultiplePayloadsDetectedDuringDispatch
 from fastapi_events.registry.payload_schema import EventPayloadSchemaRegistry
 from fastapi_events.typing import Event
 
@@ -96,6 +97,30 @@ async def test_payload_validation_with_pydantic_in_req_res_cycle(
     else:
         dispatch_fn()
         assert mocks["spy_event_store_ctx_var"].get.called
+
+
+@pytest.mark.asyncio
+async def test_dispatching_with_pydantic_model(
+    setup_mocks_for_events_in_req_res_cycle, mocker
+):
+    payload_schema = EventPayloadSchemaRegistry()
+
+    mocks = setup_mocks_for_events_in_req_res_cycle(disable_dispatch=False)
+    spy__dispatch = mocker.spy(dispatcher_module, "_dispatch")
+
+    @payload_schema.register
+    class UserSignedUpEventSchema(pydantic.BaseModel):
+        __event_name__ = "USER_SIGNED_UP"
+
+        username: str
+
+    dispatch(UserSignedUpEventSchema(username="USER_ABC"))
+
+    assert mocks["spy_event_store_ctx_var"].get.called
+    spy__dispatch.assert_called_with(
+        event_name="USER_SIGNED_UP",
+        payload={"username": "USER_ABC"}
+    )
 
 
 @pytest.mark.asyncio
@@ -206,3 +231,35 @@ async def test_otel_support(
 
     spans_created = otel_test_manager.get_finished_spans()
     assert spans_created[0].name == "Event TEST_EVENT dispatched"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_calls(
+    setup_mocks_for_events_in_req_res_cycle
+):
+    """
+    support calling dispatch with a mix of args, kwarg
+    """
+    setup_mocks_for_events_in_req_res_cycle(disable_dispatch=True)
+
+    class SchemaA(pydantic.BaseModel):
+        __event_name__ = "EVENT_A"
+
+        username: str
+
+    # Valid combinations of arguments
+    dispatch(SchemaA(username="USER_ABC"))
+    dispatch("EVENT_A")
+    dispatch("EVENT_A", {"username": "ABC"})
+    dispatch("EVENT_A", payload={"username": "ABC"})
+    dispatch(event_name="EVENT_A", payload={"username": "ABC"})
+
+    # Invalid combinations
+    with pytest.raises(MultiplePayloadsDetectedDuringDispatch):
+        dispatch(SchemaA(username="USER_ABC"),
+                 event_name="XYZ",
+                 payload={"username": "USER_ABC"})
+
+    with pytest.raises(MultiplePayloadsDetectedDuringDispatch):
+        dispatch(SchemaA(username="USER_ABC"),
+                 payload={"username": "USER_ABC"})

--- a/tests/test_event_payload_schema_registry.py
+++ b/tests/test_event_payload_schema_registry.py
@@ -1,0 +1,88 @@
+from enum import Enum
+
+import pydantic
+import pytest
+
+from fastapi_events.errors import MissingEventNameDuringRegistration
+from fastapi_events.registry.payload_schema import EventPayloadSchemaRegistry
+
+
+class UserEvents(Enum):
+    SIGNED_UP = "USER_SIGNED_UP"
+
+
+class _SignUpEventSchema(pydantic.BaseModel):
+    username: str
+
+
+class _SignUpEventSchemaWithEventName(_SignUpEventSchema):
+    __event_name__: str = "USER_SIGNED_UP"
+
+
+@pytest.fixture
+def registry():
+    return EventPayloadSchemaRegistry()
+
+
+@pytest.mark.parametrize(
+    "event_name",
+    (UserEvents.SIGNED_UP,
+     "USER_SIGNED_UP",)
+)
+async def test_schema_registration_with_explicit_event_name(
+    event_name, registry
+):
+    """
+    Event name provided explicitly (both of string and enum type)
+    """
+    registry.register(event_name=event_name)(_SignUpEventSchema)
+
+    assert registry[event_name] == _SignUpEventSchema
+
+
+async def test_schema_registration_with_event_name_from_schema_1(
+    registry
+):
+    """
+    Event name defined in schema as the value of __event_name__
+    """
+
+    @registry.register()
+    class Schema(_SignUpEventSchemaWithEventName):
+        ...
+
+    assert registry[Schema.__event_name__] \
+           == registry["USER_SIGNED_UP"] \
+           == Schema
+
+
+async def test_schema_registration_with_event_name_from_schema_2(
+    registry
+):
+    """
+    Event name defined in schema as the value of __event_name__
+    """
+
+    @registry.register
+    class Schema(_SignUpEventSchemaWithEventName):
+        ...
+
+    assert registry[Schema.__event_name__] \
+           == registry["USER_SIGNED_UP"] \
+           == Schema
+
+
+async def test_schema_registration_without_event_name(
+    registry
+):
+    """
+    MissingEventNameDuringRegistration should be raised
+    when event_name is not provided and __event_name__ is not defined.
+    """
+    with pytest.raises(MissingEventNameDuringRegistration):
+        @registry.register  # event_name is not provided
+        class Schema(pydantic.BaseModel):
+            # __event_name__ is not provided
+            ...
+
+    assert len(registry) == 0

--- a/tests/test_event_payload_schema_registry.py
+++ b/tests/test_event_payload_schema_registry.py
@@ -29,7 +29,7 @@ def registry():
     (UserEvents.SIGNED_UP,
      "USER_SIGNED_UP",)
 )
-async def test_schema_registration_with_explicit_event_name(
+def test_schema_registration_with_explicit_event_name(
     event_name, registry
 ):
     """
@@ -40,7 +40,7 @@ async def test_schema_registration_with_explicit_event_name(
     assert registry[event_name] == _SignUpEventSchema
 
 
-async def test_schema_registration_with_event_name_from_schema_1(
+def test_schema_registration_with_event_name_from_schema_1(
     registry
 ):
     """
@@ -56,7 +56,7 @@ async def test_schema_registration_with_event_name_from_schema_1(
            == Schema
 
 
-async def test_schema_registration_with_event_name_from_schema_2(
+def test_schema_registration_with_event_name_from_schema_2(
     registry
 ):
     """
@@ -72,7 +72,7 @@ async def test_schema_registration_with_event_name_from_schema_2(
            == Schema
 
 
-async def test_schema_registration_without_event_name(
+def test_schema_registration_without_event_name(
     registry
 ):
     """

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ commands =
 description : run test for starlite
 deps =
     {[base]deps}
+    pydantic>=1.0,<2.0
     starlite>=1.38.0,<=2
 commands =
     pytest tests/middleware/test_starlite.py

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,6 @@ commands =
 description : run test for starlite
 deps =
     {[base]deps}
-    pydantic>=1.0,<2.0
     starlite>=1.38.0,<=2
 commands =
     pytest tests/middleware/test_starlite.py


### PR DESCRIPTION
- modified the schema registry to allow the event name to be derived from the payload schema
- modified the dispatcher to allow dispatching of events with Pydantic model
   - ensure OTEL support, 
   - ensure FASTAPI_EVENTS_DISABLE_DISPATCH is still respected
- added more test cases
- updated README

Closes #50 