### PR TITLE
Serialize pydantic events before creating OTEL spans

### DIFF
--- a/fastapi_events/dispatcher.py
+++ b/fastapi_events/dispatcher.py
@@ -292,7 +292,7 @@ def dispatch(
                 )
 
         # OTEL
-        if payload and isinstance(payload, dict):
+        if payload:
             logger.debug("Injecting traceparent to event payload...")
             inject_traceparent(payload=payload)
 

--- a/fastapi_events/dispatcher.py
+++ b/fastapi_events/dispatcher.py
@@ -264,6 +264,8 @@ def dispatch(
     # Handle dispatch without event_name specified
     if not event_name and isinstance(event_name_or_model, (str, Enum)):
         event_name = event_name_or_model
+    elif hasattr(event_name_or_model, "__event_name__"):
+        event_name = event_name_or_model.__event_name__
 
     with create_span_for_dispatch_fn(event_name=event_name):
         if HAS_PYDANTIC:

--- a/fastapi_events/otel/utils.py
+++ b/fastapi_events/otel/utils.py
@@ -89,6 +89,9 @@ def inject_traceparent(payload: Dict):
         logger.debug("Unable to inject traceparent. OTEL is not installed.")
         return
 
+    if isinstance(payload, BaseModel):
+        payload = payload.model_dump()
+
     if not isinstance(payload, dict):
         logger.debug("Unable to inject traceparent. Payload is not a dict")
         return

--- a/fastapi_events/otel/utils.py
+++ b/fastapi_events/otel/utils.py
@@ -9,6 +9,7 @@ from fastapi_events.constants import FASTAPI_EVENTS_USE_SPAN_LINKING_ENV_VAR
 from fastapi_events.otel import HAS_OTEL_INSTALLED, propagate, trace
 from fastapi_events.otel.attributes import SpanAttributes
 from fastapi_events.utils import strtobool
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,9 @@ def create_span_for_handle_fn(
         return empty_span()
 
     links, context = [], None
+
+    if isinstance(payload, BaseModel):
+        payload = payload.model_dump()
 
     # Extract span from remote context
     remote_ctx = propagate.extract(payload)


### PR DESCRIPTION
OpenTelemetry `propagate.extract()` method is unable to handle Pydantic models, so they must be serialized before creating spans. Looks like the issue was introduced with #57 and only appears when Pydantic model schema dump is turned off.

In this PR we also determine the event name before creating the span. Otherwise all `dispatch` spans are named `Event None dispatched` - now the actual event name is set instead of None.

Fixes #63 
